### PR TITLE
Add scroll bar to left column only, keep rest of page in viewport

### DIFF
--- a/client/stylesheets/dashboard-page.css
+++ b/client/stylesheets/dashboard-page.css
@@ -1,7 +1,7 @@
 #dashboardLeftCol, #dashboardRightCol {
   /* Very hacky way to get both divs to take the height under the nav bar */
   /* if we ever have vertical layout issues, this is probably why */
-  height: 92vh;
+  height: 88vh;
 }
 .navbar {
   /* give only a little breathing froom between navbar and the content */


### PR DESCRIPTION
Closes #122 

I did this in a very hacky way (check the CSS), so we should check this on different screen heights and widths.

But the idea is that you never have to scroll the whole page when your screen is wide enough to show two columns. The calendar should take up the full vertical height of the right column, and you should only scroll the left column.

