### PR TITLE
make navbar elements always show and stay in the corner

### DIFF
--- a/imports/ui/pages/dashboard-page.html
+++ b/imports/ui/pages/dashboard-page.html
@@ -1,10 +1,10 @@
  <template name="dashboard_page">
 
   <body>
-<nav class="navbar navbar-toggleable-md navbar-dark bg-primary">
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
+<nav class="navbar navbar-dark bg-primary">
+            <div >
               <a class="navbar-brand" href="#">Meetable</a>
-              <ul class="nav navbar-nav navbar-right">
+              <ul class="navbar-nav navbar-right pull-right">
                   {{> atNavButton}}
               </ul>
            </div>


### PR DESCRIPTION
@cli1209 let me know if you disagree with the changes to the HTML I made. I think the navbar was disappearing because we set it to a collapsable navbar. I'm assuming we always want to display the navbar because it only have our team name and the signout button, so I made it not collapsible. I also added `.pull-right` to make the signout button stay on the right side of the page when the screen is less than 768 px wide.