### PR TITLE
put comma separators in the right place when displaying a list of participants

### DIFF
--- a/imports/ui/pages/dashboard-page.js
+++ b/imports/ui/pages/dashboard-page.js
@@ -479,10 +479,10 @@ Template.finalizedMeeting.helpers({
     var peopleList = Meetings.findOne({_id:this.toString()}).participants;
     var participants = "";
     var comma = ", ";
-    for (var i = 1; i < peopleList.length; i++) {
+    participants = participants.concat(peopleList[1].email);
+    for (var i = 2; i < peopleList.length; i++) {
+      participants = participants.concat(comma);
       participants = participants.concat(peopleList[i].email);
-      if (i > 1)
-        participants = participants.concat(comma);
     }
     return participants;
   },


### PR DESCRIPTION
put comma separators in the right place when displaying a list of
participants