### PR TITLE
Meet range

### DIFF
--- a/imports/ui/pages/dashboard-page.html
+++ b/imports/ui/pages/dashboard-page.html
@@ -186,7 +186,7 @@
                     </div>
                     <div class="col-md-10 datetimepicker">
                       <!-- TODO: this lavel text is blue probably because of the datetimepicker class on the div, Not sure if the datetimepicker class is necessary? if it is, then we can assign the label a class and change its font color -->
-                      <label for="no-meetings-before">No meetings before:</label>
+                      <label for="no-meetings-before">No meetings before</label>
                       <input id="no-meetings-before" class="set-start-date form-control" type="text" placeholder={{earliestTime}}>
                       </div>
                   </div>

--- a/imports/ui/pages/dashboard-page.js
+++ b/imports/ui/pages/dashboard-page.js
@@ -269,6 +269,11 @@ Template.dashboard_page.events({
       if (error) console.log("Error in addRecurringBusyTimes: " + error);
       Meteor.call('updateMeetableTimes', function(error, result) {
         if (error) console.log('updateBusyTimes: ' + error);
+        else {
+          var resetEarliest = document.getElementById('no-meetings-before').value ="";
+          var resetLatest = document.getElementById('no-meetings-after').value ="";
+          Bert.alert( 'Settings saved', 'success', 'growl-bottom-left', 'fa-calendar-check-o' );
+        }
       });
     });
   }


### PR DESCRIPTION
closes #208 and #234 

Placeholders for settings to show what we currently have in the database
Fix alignment for settings tab
Slight edits to the prompts text
Add alert on successfully saving settings, and clear the fields to
their default placeholders


how to test:
open settings tab
make sure the fields display your current settings
change the meeting window 
make sure the green success alert shows, and clears the fields so that they display the values currently stored in our database 