### PR TITLE
make logo unclickable

### DIFF
--- a/client/stylesheets/dashboard-page.css
+++ b/client/stylesheets/dashboard-page.css
@@ -49,6 +49,9 @@ hr {
 #meetable-name {
   font-size: 3rem;
   font-weight: bold;
+
+  display: inline-block;  /*so it will go on same line as rest of navbar*/
+  margin: 10px 0px auto 15px;
 }
 
 #events-calendar {

--- a/imports/ui/pages/dashboard-page.html
+++ b/imports/ui/pages/dashboard-page.html
@@ -1,14 +1,11 @@
  <template name="dashboard_page">
-
   <body>
-<nav class="navbar navbar-dark bg-primary">
-            <div >
-              <a class="navbar-brand" id="meetable-name" href="#">Meetable</a>
-              <ul class="navbar-nav navbar-right pull-right">
-                  {{> atNavButton}}
-              </ul>
-           </div>
-        </nav>
+    <nav class="navbar navbar-dark bg-primary">
+      <h1 id="meetable-name" class="align-middle">Meetable</h1>
+      <ul class="nav navbar-nav navbar-right">
+          {{> atNavButton}}
+      </ul>
+    </nav> 
 
     <div class="container-fluid">
       <div id="dashboard-main-row" class="row">


### PR DESCRIPTION
closes #245 

Changed `a` to `h1`. Had to removed `navbar-brand` class because when I added that class, clicking the h1.navbar-brand button signed me out. I have literally no idea why.