### PR TITLE
Stop going to Signin Page upon refresh

### DIFF
--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -34,7 +34,7 @@ public.route('/', {
   name: 'App.home',
   action: function(params) {
     Tracker.autorun(function() {
-      BlazeLayout.render('App_body', { main: 'login_page' });
+      if (!Meteor.loggingIn()) BlazeLayout.render('App_body', { main: 'login_page' });
     });
   },
   waitOn: function() {


### PR DESCRIPTION
So this fix isn't entirely elegant, but `waitOn` isn't working how I would imagine it.

I think we generally might be using FlowRouter in weird way (probably my fault 👎 ), but at this point if it works it works. RIGHT!?!?!?!?

To test:
1. Navigate all over, from ROOT/ to ROOT/dashboard while logged in and logging out.
2. Make sure nothing explodes