### PR TITLE
make datepickers readonly to keyboard input

### DIFF
--- a/imports/ui/pages/dashboard-page.html
+++ b/imports/ui/pages/dashboard-page.html
@@ -45,14 +45,14 @@
                   <div class="form-group">
                     <div class="col-md-10 datetimepicker">
                       <label for="chooseWindowStart">Scheduling Window Start</label>
-                      <input id="chooseWindowStart" class="set-start-date form-control" type="text"/>
+                      <input id="chooseWindowStart" class="set-start-date form-control" type="text" readonly/>
                     </div>
                   </div>
 
                   <div class="form-group">
                     <div class="col-md-10 datetimepicker">
                     <label for="chooseWindowEnd">Scheduling Window End</label>
-                      <input id="chooseWindowEnd" class="set-end-date form-control" type="text"/>
+                      <input id="chooseWindowEnd" class="set-end-date form-control" type="text" readonly/>
                     </div>
                   </div>
 
@@ -143,14 +143,14 @@
                   <div class="container-fluid"> <p> Add a new busy time: </p></div>
                   <div class="col-md-10 datetimepicker">
                     <label for="datetime-start">Start</label>
-                    <input id="datetime-start" class="set-start-date form-control" type="text"/>
+                    <input id="datetime-start" class="set-start-date form-control" type="text" readonly/>
                     </div>
                 </div>
 
                 <div class="form-group">
                   <div class="col-md-10 datetimepicker">
                     <label for="datetime-end">End</label>
-                    <input id="datetime-end" class="set-end-date form-control" type="text"/>
+                    <input id="datetime-end" class="set-end-date form-control" type="text" readonly/>
                   </div>
                 </div>
                 <button type = "button" class="btn btn-primary" id = "submit-extra-times">Submit</button>
@@ -183,13 +183,13 @@
                     </div>
                     <div class="col-md-10 datetimepicker">
                       <label for="no-meetings-before">No meetings before</label>
-                      <input id="no-meetings-before" class="set-start-date form-control" type="text" >
+                      <input id="no-meetings-before" class="set-start-date form-control" type="text" readonly/>
                       </div>
                   </div>
                   <div class="form-group">
                     <div class="col-md-10 datetimepicker">
                       <label for="no-meetings-after">No meetings after</label>
-                      <input id="no-meetings-after" class="set-end-date form-control" type="text" >
+                      <input id="no-meetings-after" class="set-end-date form-control" type="text" readonly/>
                     </div>
                   </div>
                   <button type = "button" class="btn btn-primary" id = "submit-no-meetings-times">Submit</button>

--- a/imports/ui/pages/dashboard-page.js
+++ b/imports/ui/pages/dashboard-page.js
@@ -174,13 +174,15 @@ Template.dashboard_page.onRendered( () => {
     useCurrent: false,
     defaultDate: roundUp,
     minDate: roundUp,
+    ignoreReadonly: true // let user use datepicker without typing manually
   });
 
   $('#chooseWindowEnd').datetimepicker({
     format: 'ddd, MMM Do, h:mm a',
     useCurrent: false,
     defaultDate: moment(roundUp).add(2, "weeks"),
-    minDate: roundUp
+    minDate: roundUp,
+    ignoreReadonly: true // let user use datepicker without typing manually
   });
 
   // datetime-start and end are for busy times
@@ -188,11 +190,14 @@ Template.dashboard_page.onRendered( () => {
   $('#datetime-start').datetimepicker({
     format: 'ddd, MMM Do, h:mm a',
     minDate: moment().startOf("hour"),
+    ignoreReadonly: true // let user use datepicker without typing manually
+
   });
 
   $('#datetime-end').datetimepicker({
     format: 'ddd, MMM Do, h:mm a',
     minDate: moment().startOf("hour"),
+    ignoreReadonly: true // let user use datepicker without typing manually
   });
 
   var earliest = Meteor.users.findOne(Meteor.userId()).profile.meetRange.earliest;
@@ -210,12 +215,14 @@ Template.dashboard_page.onRendered( () => {
 
   $('#no-meetings-before').datetimepicker({
     format: 'h:mm a',
-    defaultDate: moment(earliest, "hh:mm")
+    defaultDate: moment(earliest, "hh:mm"),
+    ignoreReadonly: true // let user use datepicker without typing manually
   });
 
   $('#no-meetings-after').datetimepicker({
     format: 'h:mm a',
-    defaultDate: moment(latest, "hh:mm")
+    defaultDate: moment(latest, "hh:mm"),
+    ignoreReadonly: true // let user use datepicker without typing manually
   });
 });
 


### PR DESCRIPTION
closes #254 

needs to be tested on mobile but it should probably work #famouslastwords.

I don't really like the idea of disabling keyboard input to fix the bug but it seems to work so it's ok for now.