### PR TITLE
Change meeting 'Save' to 'Submit' and settings 'Submit' to 'Save'

### DIFF
--- a/imports/ui/pages/dashboard-page.html
+++ b/imports/ui/pages/dashboard-page.html
@@ -59,7 +59,7 @@
                   <div class="form-group">
                     <div class="col-md-10 col-md-offset-2">
                       <button type="button" class="btn btn-default" id="cancelCreateMeeting">Cancel</button>
-                      <button type="save" class="btn btn-primary" id="save">Save</button>
+                      <button type="save" class="btn btn-primary" id="save">Submit</button>
                     </div>
                   </div>
                 </fieldset>
@@ -192,7 +192,7 @@
                       <input id="no-meetings-after" class="set-end-date form-control" type="text" readonly/>
                     </div>
                   </div>
-                  <button type = "button" class="btn btn-primary" id = "submit-no-meetings-times">Submit</button>
+                  <button type = "button" class="btn btn-primary" id = "submit-no-meetings-times">Save</button>
                 </form>
               </div>
             </div>


### PR DESCRIPTION
Change meeting 'Save' to 'Submit' and settings 'Submit' to 'Save' 

Didn’t bother to change the id of the meetings submit button, just
changed the label.

This is a tiny change so I doubt there will be issues but can people just test to make sure sending invites and changing settings still works? 