### PR TITLE
fix display for an incoming invite where the user is not the selector, make it match the others

### DIFF
--- a/imports/ui/pages/dashboard-page.html
+++ b/imports/ui/pages/dashboard-page.html
@@ -257,9 +257,11 @@
   <div class="row container-fluid">
     <div class="card invite-card">
       <div class="card-block invite-card-block">
-        <div class="col-md-12">
-          Waiting on <h4>{{inviterName}}</h4> to select a time for <b>{{meetingTitle}}</b> (Event Duration: {{meetingDuration}})
-        </div>
+          <span class="label label-primary">Accepted, waiting for host to finalize time.</span>
+            <div class="col-md-12">
+              <h4>{{inviterName}}</h4> <p>invites you to <b>{{meetingTitle}}</b> ({{meetingDuration}})</p>
+              <p> Scheduling Window: <br> {{incomingWindowRange}}</p>
+            </div>
       </div>
     </div>
   </div>

--- a/imports/ui/pages/dashboard-page.js
+++ b/imports/ui/pages/dashboard-page.js
@@ -600,6 +600,19 @@ Template.notSelector.helpers({
       return hour + "hr " + minute + "min";
     }
   },
+  incomingWindowRange() {
+    var meeting = Meetings.findOne(this.toString());
+    if (meeting && meeting.windowStart && meeting.windowEnd) {
+      let windowStart = Meetings.findOne(this.toString()).windowStart;
+      let windowEnd = Meetings.findOne(this.toString()).windowEnd;
+
+      return moment(windowStart).twix(moment(windowEnd)).format({
+        showDayOfWeek: true,
+        weekdayFormat: "ddd,",
+        meridiemFormat: "a",
+      });
+    }
+  }
 });
 
 Template.selector.helpers({


### PR DESCRIPTION
fix display for an incoming invite where the user is not the selector,
make it match the others

Before:

![screen shot 2017-05-13 at 9 00 20 pm](https://cloud.githubusercontent.com/assets/9685638/26030403/d3859dea-3820-11e7-808a-a4769d7cf148.png)


After: 

![screen shot 2017-05-13 at 9 09 28 pm](https://cloud.githubusercontent.com/assets/9685638/26030394/94842ea4-3820-11e7-90c0-deaebd1ed843.png)


How to check: 
the exact steps I took to find this problem were
1) make a group meeting
2) have one person in the group meeting decline the meeting
3) sign in to the third person's account, and accept. Make sure that the display for the invite looks good, and isn't like the 'before' picture I posted above.